### PR TITLE
Replace unsubstantiated 'World Class' tagline with 'Interactive'

### DIFF
--- a/src/app/experiments/doppler/page.tsx
+++ b/src/app/experiments/doppler/page.tsx
@@ -4,4 +4,4 @@ export const dynamic = 'force-dynamic';
 
 export default function DopplerRoute() { return <DopplerPage />; }
 
-export const metadata = { title: "Doppler Effect - World Class Physics Lab", description: "Interactive 3D Doppler effect simulation with real-time frequency shift visualization." };
+export const metadata = { title: "Doppler Effect - Interactive Physics Lab", description: "Interactive 3D Doppler effect simulation with real-time frequency shift visualization." };

--- a/src/app/experiments/double-slit/page.tsx
+++ b/src/app/experiments/double-slit/page.tsx
@@ -4,4 +4,4 @@ export const dynamic = 'force-dynamic';
 
 export default function DoubleSlitRoute() { return <DoubleSlitPage />; }
 
-export const metadata = { title: "Double Slit - World Class Physics Lab", description: "Interactive 3D double slit experiment with intensity graph and fringe visualization." };
+export const metadata = { title: "Double Slit - Interactive Physics Lab", description: "Interactive 3D double slit experiment with intensity graph and fringe visualization." };

--- a/src/app/experiments/electromagnetic/page.tsx
+++ b/src/app/experiments/electromagnetic/page.tsx
@@ -4,4 +4,4 @@ export const dynamic = 'force-dynamic';
 
 export default function ElectromagneticRoute() { return <ElectromagneticPage />; }
 
-export const metadata = { title: "Electromagnetic Field - World Class Physics Lab", description: "Interactive 3D electromagnetic field visualization with field lines, equipotential surfaces, and force vectors." };
+export const metadata = { title: "Electromagnetic Field - Interactive Physics Lab", description: "Interactive 3D electromagnetic field visualization with field lines, equipotential surfaces, and force vectors." };

--- a/src/app/experiments/gas-laws/page.tsx
+++ b/src/app/experiments/gas-laws/page.tsx
@@ -5,6 +5,6 @@ export const dynamic = 'force-dynamic';
 export default function GasLawsRoute() { return <GasLawsPage />; }
 
 export const metadata = {
-  title: "Gas Laws - World Class Physics Lab",
+  title: "Gas Laws - Interactive Physics Lab",
   description: "Interactive 3D ideal gas law simulation with pressure gauge, particle physics, and PV diagram.",
 };

--- a/src/app/experiments/gravitational-orbits/page.tsx
+++ b/src/app/experiments/gravitational-orbits/page.tsx
@@ -4,4 +4,4 @@ export const dynamic = 'force-dynamic';
 
 export default function GravitationalOrbitsRoute() { return <GravitationalOrbitsPage />; }
 
-export const metadata = { title: "Gravitational Orbits - World Class Physics Lab", description: "Interactive 3D orbital mechanics simulation with real-time gravitational physics." };
+export const metadata = { title: "Gravitational Orbits - Interactive Physics Lab", description: "Interactive 3D orbital mechanics simulation with real-time gravitational physics." };

--- a/src/app/experiments/pendulum/page.tsx
+++ b/src/app/experiments/pendulum/page.tsx
@@ -20,6 +20,6 @@ export default function PendulumRoute() {
 }
 
 export const metadata = {
-  title: "Simple Pendulum - World Class Physics Lab",
+  title: "Simple Pendulum - Interactive Physics Lab",
   description: "Interactive 3D pendulum simulation with accurate physics, real-time data visualization, and energy conservation display.",
 };

--- a/src/app/experiments/projectile-motion/page.tsx
+++ b/src/app/experiments/projectile-motion/page.tsx
@@ -19,6 +19,6 @@ export default function ProjectileMotionRoute() {
 }
 
 export const metadata = {
-  title: "Projectile Motion - World Class Physics Lab",
+  title: "Projectile Motion - Interactive Physics Lab",
   description: "Interactive 3D projectile simulation with air resistance, trajectory prediction, and real-time data visualization.",
 };

--- a/src/app/experiments/refraction/page.tsx
+++ b/src/app/experiments/refraction/page.tsx
@@ -4,4 +4,4 @@ export const dynamic = 'force-dynamic';
 
 export default function RefractionRoute() { return <RefractionPage />; }
 
-export const metadata = { title: "Refraction - World Class Physics Lab", description: "Interactive 3D refraction and reflection simulation with Snell's law and total internal reflection." };
+export const metadata = { title: "Refraction - Interactive Physics Lab", description: "Interactive 3D refraction and reflection simulation with Snell's law and total internal reflection." };

--- a/src/app/experiments/spring-mass/page.tsx
+++ b/src/app/experiments/spring-mass/page.tsx
@@ -4,4 +4,4 @@ export const dynamic = 'force-dynamic';
 
 export default function SpringMassRoute() { return <SpringMassPage />; }
 
-export const metadata = { title: "Spring-Mass - World Class Physics Lab", description: "Interactive 3D spring-mass system with energy conservation visualization and real-time data." };
+export const metadata = { title: "Spring-Mass - Interactive Physics Lab", description: "Interactive 3D spring-mass system with energy conservation visualization and real-time data." };

--- a/src/app/experiments/wave-interference/page.tsx
+++ b/src/app/experiments/wave-interference/page.tsx
@@ -7,6 +7,6 @@ export default function WaveInterferenceRoute() {
 }
 
 export const metadata = {
-  title: "Wave Interference - World Class Physics Lab",
+  title: "Wave Interference - Interactive Physics Lab",
   description: "Interactive 3D wave interference simulation with realistic water physics and node/antinode visualization.",
 };


### PR DESCRIPTION
Replace 'World Class Physics Lab' with 'Interactive Physics Lab' in all 10 experiment page metadata titles. The original claim is unsubstantiated and could be seen as misleading.